### PR TITLE
Update stale clojars badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Clojars Project](https://img.shields.io/clojars/v/deps-deploy.svg)](https://clojars.org/deps-deploy)
+[![Clojars Project](https://img.shields.io/clojars/v/slipset/deps-deploy.svg)](https://clojars.org/slipset/deps-deploy)
 # deps-deploy
 
 A Clojure library to deploy your stuff to clojars with `clj` or `clojure`. It's a very thin wrapper around


### PR DESCRIPTION
Badge is pointing to old maven coords (effectively deps-deploy/deps-deploy), updated to slipset/deps-deploy.