### PR TITLE
Allow for the repository URL to be overridden.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file. This change
 ## [Unreleased]
 ### Changed
 - Add a new arity to `make-widget-async` to provide a different widget shape.
+- Allow for the repository url to be overridden, e.g., `CLOJARS_URL=https://internal/repository/maven-releases`
 
 ## [0.1.1] - 2018-11-04
 ### Changed

--- a/README.md
+++ b/README.md
@@ -21,7 +21,16 @@ into your `deps.edn`, have a `pom.xml` handy (you can generate one with `clj -Sp
 $ env CLOJARS_USERNAME=username CLOJARS_PASSWORD=clojars-token clj -A:deploy
 ```
 
-to deploy to Clojars. 
+to deploy to Clojars.
+
+It is also possible to override the default Clojars URL by supplying your own. For example:
+
+```sh
+$ env CLOJARS_URL=https://internal/repository/maven-releases CLOJARS_USERNAME=username CLOJARS_PASSWORD=password clj -A:deploy
+```
+
+This facilitates deploying artefacts to an internal repository - perhaps a proxy service that is running locally that is used
+to hold private JARs etc...
 
 ### A note on Clojars tokens
 

--- a/src/deps_deploy/deps_deploy.clj
+++ b/src/deps_deploy/deps_deploy.clj
@@ -6,7 +6,7 @@
             [clojure.java.io :as io]
             [clojure.data.xml :as xml]))
 
-(def default-repo-settings {"clojars" {:url "https://clojars.org/repo"
+(def default-repo-settings {"clojars" {:url (or (System/getenv "CLOJARS_URL") "https://clojars.org/repo")
                                        :username (System/getenv "CLOJARS_USERNAME")
                                        :password (System/getenv "CLOJARS_PASSWORD")}})
 
@@ -66,12 +66,13 @@
 (defmulti deploy :installer)
 
 (defmethod deploy :clojars [{:keys [artifact-map coordinates repository]
-                             :or {repository default-repo-settings} :as opts }]
+                             :or {repository default-repo-settings} :as opts}]
   (println "Deploying" (str (first coordinates) "-" (second coordinates)) "to clojars as"
            (-> repository vals first :username))
   (aether/deploy :artifact-map artifact-map
                  :repository repository
-                 :coordinates coordinates))
+                 :coordinates coordinates)
+  (println "done."))
 
 (defmethod deploy :local [{:keys [artifact-map coordinates]}]
   (println "Installing" (str (first coordinates) "-" (second coordinates)) "to your local `.m2`")


### PR DESCRIPTION
It is often advantageous to allow the URL of the repository to be overridden.
This will permit the upload of artefacts to local proxies that are hosting
content.

-=david=-