### PR TITLE
Refactor to support calling via a clojure -X :exec-fn

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -14,7 +14,17 @@
                "-d" "test"]}
   :depstar {:extra-deps
             {seancorfield/depstar {:mvn/version "1.1.117"}}}
-  :deploy {:main-opts ["-m" "deps-deploy.deps-deploy" "deploy"
-                       "deps-deploy.jar" true]}
-  :install {:main-opts ["-m" "deps-deploy.deps-deploy" "install"
-                        "deps-deploy.jar"]}}}
+
+  :deploy {:exec-fn deps-deploy.deps-deploy/deploy
+           :exec-args {:installer :remote
+                       :sign-releases? true
+                       :artifact "deps-deploy.jar"
+
+                       :repository {"clojars" {:url "https://clojars.org/repo"
+                                               :username "your-username"
+                                               :password "CLOJARS_your-deploy-token"}}}}
+
+  :install {:exec-fn deps-deploy.deps-deploy/deploy
+            :exec-args {:installer :local
+                        :artifact "deps-deploy.jar"}
+            }}}


### PR DESCRIPTION
Closes #16

This adds a new `deploy` function that can be used with `:exec-fn` and `:exec-args`.  

In making this change I renamed the deploy multi-method to `deploy*` and consequently there is a chance this may break any users who were extending this multimethod.  

I also rename the `:clojars` key to `:remote` to indicate the mechanism for repositories is more generic than just clojars.

Extending `:remote` to support S3 repositories will be implemented in a follow up PR.