### PR TITLE
Support using private S3 buckets as remote mvn deployment targets

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,4 +1,4 @@
-{:paths ["src" "resources"]
+{:paths ["src"]
  :deps {org.clojure/clojure {:mvn/version "RELEASE"}
         com.cemerick/pomegranate {:mvn/version "RELEASE"}
         s3-wagon-private/s3-wagon-private {:mvn/version "1.3.1"}

--- a/deps.edn
+++ b/deps.edn
@@ -1,6 +1,7 @@
 {:paths ["src" "resources"]
  :deps {org.clojure/clojure {:mvn/version "RELEASE"}
         com.cemerick/pomegranate {:mvn/version "RELEASE"}
+        s3-wagon-private/s3-wagon-private {:mvn/version "1.3.1"}
         org.clojure/data.xml {:mvn/version "0.2.0-alpha5"}
         org.slf4j/slf4j-nop {:mvn/version "RELEASE"}}
  :aliases

--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,11 @@
       <version>2.0.0-alpha1</version>
     </dependency>
     <dependency>
+      <groupId>s3-wagon-private</groupId>
+      <artifactId>s3-wagon-private</artifactId>
+      <version>1.3.1</version>
+    </dependency>
+    <dependency>
       <groupId>com.cemerick</groupId>
       <artifactId>pomegranate</artifactId>
       <version>1.1.0</version>

--- a/src/deps_deploy/deps_deploy.clj
+++ b/src/deps_deploy/deps_deploy.clj
@@ -4,7 +4,14 @@
             [clojure.edn :as edn]
             [clojure.pprint :as pp]
             [clojure.java.io :as io]
-            [clojure.data.xml :as xml]))
+            [clojure.data.xml :as xml])
+  (:import [org.springframework.build.aws.maven
+            PrivateS3Wagon SimpleStorageServiceWagon]))
+
+
+(aether/register-wagon-factory! "s3p" #(PrivateS3Wagon.))
+(aether/register-wagon-factory! "s3" #(SimpleStorageServiceWagon.))
+
 
 (def default-repo-settings {"clojars" {:url (or (System/getenv "CLOJARS_URL") "https://clojars.org/repo")
                                        :username (System/getenv "CLOJARS_USERNAME")

--- a/src/deps_deploy/deps_deploy.clj
+++ b/src/deps_deploy/deps_deploy.clj
@@ -84,10 +84,17 @@
 
 (defmulti deploy* :installer)
 
+(defn- print-deploy-message [{:keys [repository coordinates]}]
+  ;; NOTE: pomegranate seems to assume the map contains only a single
+  ;; repository-id/settings pair.
+  (let [id (-> repository keys first)
+        settings (-> repository vals first)]
+    (println "Deploying" (artifact coordinates) "to repository" id "as"
+             (:username settings))))
+
 (defmethod deploy* :remote [{:keys [artifact-map coordinates repository]
                              :or {repository default-repo-settings} :as opts}]
-  (println "Deploying" (artifact coordinates) "to clojars as"
-           (-> repository vals first :username))
+  (print-deploy-message opts)
   (java.lang.System/setProperty "aether.checksums.forSignature" "true")
   (aether/deploy :artifact-map artifact-map
                  :repository repository


### PR DESCRIPTION
Works via S3 wagon.

This PR builds on and includes commits from #18 which also adds exec-fn support.