### PR TITLE
Support overriding pom.xml version via :exec-args and cli

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -14,7 +14,17 @@
                "-d" "test"]}
   :depstar {:extra-deps
             {seancorfield/depstar {:mvn/version "1.1.117"}}}
-  :deploy {:main-opts ["-m" "deps-deploy.deps-deploy" "deploy"
-                       "deps-deploy.jar" true]}
-  :install {:main-opts ["-m" "deps-deploy.deps-deploy" "install"
-                        "deps-deploy.jar"]}}}
+
+  :deploy {:exec-fn deps-deploy.deps-deploy/deploy
+           :exec-args {:installer :remote
+                       :sign-releases? true
+                       :artifact "deps-deploy.jar"
+
+                       :repository {"clojars" {:url "https://clojars.org/repo"
+                                               :username "your-username"
+                                               :password "CLOJARS_your-deploy-token"}}}}
+
+  :install {:exec-fn deps-deploy.deps-deploy/deploy
+            :exec-args {:installer :local
+                        :artifact "deps-deploy.jar"}
+            }}}

--- a/deps.edn
+++ b/deps.edn
@@ -1,6 +1,7 @@
 {:paths ["src" "resources"]
  :deps {org.clojure/clojure {:mvn/version "RELEASE"}
         com.cemerick/pomegranate {:mvn/version "RELEASE"}
+        s3-wagon-private/s3-wagon-private {:mvn/version "1.3.1"}
         org.clojure/data.xml {:mvn/version "0.2.0-alpha5"}
         org.slf4j/slf4j-nop {:mvn/version "RELEASE"}}
  :aliases

--- a/src/deps_deploy/deps_deploy.clj
+++ b/src/deps_deploy/deps_deploy.clj
@@ -6,6 +6,11 @@
             [clojure.java.io :as io]
             [clojure.data.xml :as xml]))
 
+
+(aether/register-wagon-factory! "s3p" #(org.springframework.build.aws.maven.PrivateS3Wagon.))
+(aether/register-wagon-factory! "s3" #(org.springframework.build.aws.maven.SimpleStorageServiceWagon.))
+
+
 (def default-repo-settings {"clojars" {:url (or (System/getenv "CLOJARS_URL") "https://clojars.org/repo")
                                        :username (System/getenv "CLOJARS_USERNAME")
                                        :password (System/getenv "CLOJARS_PASSWORD")}})


### PR DESCRIPTION
Implements #20 

Extends PR #18 to support overriding a version number in a pom.xml.  This allows CI systems etc to easily deploy an artifact with a generated build number, or for a version override to be supplied via the CLI when using `:exec-fn`