### PR TITLE
Bump s3-wagon-private dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,12 +33,12 @@ to hold private JARs etc...
 
 ### Deploy to private s3 buckets
 
-To deploy to private s3 bucktes, you first need to specified the `:repository` key in your `deps.edn` alias as `:exec-args` as
+To deploy to private s3 buckets, you first need to specify the `:repository` key in your `deps.edn` alias with `:exec-args` as:
 
 ```clj
 :exec-args {:repository {"releases" {:url "s3p://my/bucket/"}}}
 ```
-Then, when deploying, you need to provide credentials which is done either by 
+Then, when deploying, you need to provide credentials which is done either by:
 
 1. setting the env vars: AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY
 2. providing them via java system properties aws.accessKeyId and aws.secretKey
@@ -50,7 +50,7 @@ or
 [default]
 aws_access_key_id = AKIAXXXXX
 aws_secret_access_key = SECRET_KEY
-``` 
+```
 For more details see [s3-wagon-provider](https://github.com/s3-wagon-private/s3-wagon-private#aws-credential-providers) and if you need to know how to [configure an S3 bucket see here](https://github.com/s3-wagon-private/s3-wagon-private#aws-policy).
 
 ### A note on Clojars tokens

--- a/deps.edn
+++ b/deps.edn
@@ -1,7 +1,7 @@
 {:paths ["src"]
  :deps {org.clojure/clojure {:mvn/version "RELEASE"}
         com.cemerick/pomegranate {:mvn/version "RELEASE"}
-        s3-wagon-private/s3-wagon-private {:mvn/version "1.3.1"}
+        s3-wagon-private/s3-wagon-private {:mvn/version "1.3.2"}
         org.clojure/data.xml {:mvn/version "0.2.0-alpha5"}
         org.slf4j/slf4j-nop {:mvn/version "RELEASE"}}
  :aliases

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
     <dependency>
       <groupId>s3-wagon-private</groupId>
       <artifactId>s3-wagon-private</artifactId>
-      <version>1.3.1</version>
+      <version>1.3.2</version>
     </dependency>
     <dependency>
       <groupId>com.cemerick</groupId>


### PR DESCRIPTION
Version 1.3.2 of s3-wagon-private fixes a version incompatibility with Java 10+.

Prior to library upgrade, users may see errors like:

```
Execution error (ClassNotFoundException) at jdk.internal.loader.BuiltinClassLoader/loadClass (BuiltinClassLoader.java:606).
javax.xml.bind.JAXBException
```

I tested this initially by overriding the s3-wagon-private dependency:

```
:override-deps {s3-wagon-private/s3-wagon-private {:mvn/version "1.3.2"}}
```