### PR TITLE
Allow artifact to be specified by clojure command

### DIFF
--- a/src/deps_deploy/deps_deploy.clj
+++ b/src/deps_deploy/deps_deploy.clj
@@ -132,7 +132,8 @@
   "
   [{:keys [pom-file sign-releases? artifact] :as opts}]
   (let [pom (slurp (or pom-file "pom.xml"))
-        coordinates (coordinates-from-pom pom)]
+        coordinates (coordinates-from-pom pom)
+        artifact (str artifact)]
     (spit (versioned-pom-filename coordinates) pom)
 
     (try


### PR DESCRIPTION
### Problem

Currently `:artifct` must be set in `deps.edn`, and when I set by `clojure` command, the follwoing error is occurred.

```
$ clojure -X:install :artifact 'foo.jar'

Execution error (ClassCastException) at deps-deploy.deps-deploy/extension (deps_deploy.clj:26).
clojure.lang.Symbol cannot be cast to java.lang.CharSequence
```

### How to solve

Params for `-X` option seems to be handled as `Symbol`, so I corerce `artifact` to `String`.