### PR TITLE
support exec-args value lookups, issue #26

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -4,7 +4,6 @@
         s3-wagon-private/s3-wagon-private {:mvn/version "1.3.2"}
         org.clojure/data.xml {:mvn/version "0.2.0-alpha5"}
         org.slf4j/slf4j-nop {:mvn/version "RELEASE"}
-        medley/medley {:mvn/version "1.3.0"}
         org.clojure/tools.deps.alpha {:mvn/version "0.9.863"}}
  :aliases
  {:test {:extra-paths ["test"]
@@ -16,15 +15,13 @@
    :main-opts ["-m" "cognitect.test-runner"
                "-d" "test"]}
 
-  :mvn/artifact-id       deps-deploy
-  :mvn/group-id          com.dcj
-  :mvn/version           "2.0.999-SNAPSHOT"
-  :jar/file-name      "deps-deploy.jar"
+  :mvn/artifact-id deps-deploy
+  :mvn/group-id    com.dcj
+  :mvn/version     "2.0.999-SNAPSHOT"
+  :jar/file-name   "deps-deploy.jar"
 
   :depstar {:replace-deps
-            {com.github.seancorfield/depstar ; 2.0.next:
-             {:git/url "https://github.com/seancorfield/depstar"
-              :sha "5f4df9ffece4769d01559f7914bd88de024e1348"}}
+            {com.github.seancorfield/depstar {:mvn/version "2.0.211"}}
             :exec-fn hf.depstar/jar
             :exec-args {:jar         :jar/file-name
                         :artifact-id :mvn/artifact-id

--- a/deps.edn
+++ b/deps.edn
@@ -16,9 +16,9 @@
    :main-opts ["-m" "cognitect.test-runner"
                "-d" "test"]}
 
-  :artifact-id       deps-deploy
-  :group-id          com.dcj
-  :version           "2.0.999-SNAPSHOT"
+  :mvn/artifact-id       deps-deploy
+  :mvn/group-id          com.dcj
+  :mvn/version           "2.0.999-SNAPSHOT"
   :jar/filename      "deps-deploy.jar"
 
   :depstar {:replace-deps
@@ -27,9 +27,9 @@
               :sha "5f4df9ffece4769d01559f7914bd88de024e1348"}}
             :exec-fn hf.depstar/jar
             :exec-args {:jar         :jar/filename
-                        :artifact-id :artifact-id
-                        :group-id    :group-id
-                        :version     :version
+                        :artifact-id :mvn/artifact-id
+                        :group-id    :mvn/group-id
+                        :version     :mvn/version
                         :sync-pom true}}
 
   :deploy {:extra-deps {com.dcj/deps-deploy {:mvn/version "2.0.999-SNAPSHOT"}}

--- a/deps.edn
+++ b/deps.edn
@@ -4,7 +4,7 @@
         s3-wagon-private/s3-wagon-private {:mvn/version "1.3.2"}
         org.clojure/data.xml {:mvn/version "0.2.0-alpha5"}
         org.slf4j/slf4j-nop {:mvn/version "RELEASE"}
-        medley {:mvn/version "1.3.0"}
+        medley/medley {:mvn/version "1.3.0"}
         org.clojure/tools.deps.alpha {:mvn/version "0.9.863"}}
  :aliases
  {:test {:extra-paths ["test"]
@@ -19,14 +19,14 @@
   :mvn/artifact-id       deps-deploy
   :mvn/group-id          com.dcj
   :mvn/version           "2.0.999-SNAPSHOT"
-  :jar/filename      "deps-deploy.jar"
+  :jar/file-name      "deps-deploy.jar"
 
   :depstar {:replace-deps
             {com.github.seancorfield/depstar ; 2.0.next:
              {:git/url "https://github.com/seancorfield/depstar"
               :sha "5f4df9ffece4769d01559f7914bd88de024e1348"}}
             :exec-fn hf.depstar/jar
-            :exec-args {:jar         :jar/filename
+            :exec-args {:jar         :jar/file-name
                         :artifact-id :mvn/artifact-id
                         :group-id    :mvn/group-id
                         :version     :mvn/version
@@ -36,9 +36,9 @@
            :exec-fn deps-deploy.deps-deploy/deploy
            :exec-args {:installer :remote
                        :sign-releases? true
-                       :artifact :jar/filename}}
+                       :artifact :jar/file-name}}
 
   :install {:extra-deps {com.dcj/deps-deploy {:mvn/version "2.0.999-SNAPSHOT"}}
             :exec-fn deps-deploy.deps-deploy/deploy
             :exec-args {:installer :local
-                        :artifact :jar/filename}}}}
+                        :artifact :jar/file-name}}}}

--- a/deps.edn
+++ b/deps.edn
@@ -3,7 +3,9 @@
         com.cemerick/pomegranate {:mvn/version "RELEASE"}
         s3-wagon-private/s3-wagon-private {:mvn/version "1.3.2"}
         org.clojure/data.xml {:mvn/version "0.2.0-alpha5"}
-        org.slf4j/slf4j-nop {:mvn/version "RELEASE"}}
+        org.slf4j/slf4j-nop {:mvn/version "RELEASE"}
+        medley {:mvn/version "1.3.0"}
+        org.clojure/tools.deps.alpha {:mvn/version "0.9.863"}}
  :aliases
  {:test {:extra-paths ["test"]
          :extra-deps {org.clojure/test.check {:mvn/version "RELEASE"}}}
@@ -14,17 +16,29 @@
    :main-opts ["-m" "cognitect.test-runner"
                "-d" "test"]}
 
-  :depstar {:replace-deps
-            {seancorfield/depstar {:mvn/version "2.0.165"}}
-            :exec-fn hf.depstar/jar
-            :exec-args {:jar deps-deploy.jar}}
+  :artifact-id       deps-deploy
+  :group-id          com.dcj
+  :version           "2.0.999-SNAPSHOT"
+  :jar/filename      "deps-deploy.jar"
 
-  :deploy {:exec-fn deps-deploy.deps-deploy/deploy
+  :depstar {:replace-deps
+            {com.github.seancorfield/depstar ; 2.0.next:
+             {:git/url "https://github.com/seancorfield/depstar"
+              :sha "5f4df9ffece4769d01559f7914bd88de024e1348"}}
+            :exec-fn hf.depstar/jar
+            :exec-args {:jar         :jar/filename
+                        :artifact-id :artifact-id
+                        :group-id    :group-id
+                        :version     :version
+                        :sync-pom true}}
+
+  :deploy {:extra-deps {com.dcj/deps-deploy {:mvn/version "2.0.999-SNAPSHOT"}}
+           :exec-fn deps-deploy.deps-deploy/deploy
            :exec-args {:installer :remote
                        :sign-releases? true
-                       :artifact "deps-deploy.jar"}}
+                       :artifact :jar/filename}}
 
-  :install {:exec-fn deps-deploy.deps-deploy/deploy
+  :install {:extra-deps {com.dcj/deps-deploy {:mvn/version "2.0.999-SNAPSHOT"}}
+            :exec-fn deps-deploy.deps-deploy/deploy
             :exec-args {:installer :local
-                        :artifact "deps-deploy.jar"}
-            }}}
+                        :artifact :jar/filename}}}}

--- a/pom.xml
+++ b/pom.xml
@@ -1,21 +1,26 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>slipset</groupId>
+  <packaging>jar</packaging>
+  <groupId>com.dcj</groupId>
   <artifactId>deps-deploy</artifactId>
-  <version>0.1.4</version>
+  <version>2.0.999-SNAPSHOT</version>
   <name>deps-deploy</name>
-  <scm>
-    <connection>scm:git:git://github.com/slipset/deps-deploy.git</connection>
-    <developerConnection>scm:git:ssh://git@github.com/slipset/deps-deploy.git</developerConnection>
-    <tag/>
-    <url>https://github.com/slipset/deps-deploy</url>
-  </scm>
   <dependencies>
     <dependency>
       <groupId>org.clojure</groupId>
       <artifactId>clojure</artifactId>
-      <version>1.10.2-rc1</version>
+      <version>RELEASE</version>
+    </dependency>
+    <dependency>
+      <groupId>com.cemerick</groupId>
+      <artifactId>pomegranate</artifactId>
+      <version>RELEASE</version>
+    </dependency>
+    <dependency>
+      <groupId>s3-wagon-private</groupId>
+      <artifactId>s3-wagon-private</artifactId>
+      <version>1.3.2</version>
     </dependency>
     <dependency>
       <groupId>org.clojure</groupId>
@@ -25,17 +30,17 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-nop</artifactId>
-      <version>2.0.0-alpha1</version>
+      <version>RELEASE</version>
     </dependency>
     <dependency>
-      <groupId>s3-wagon-private</groupId>
-      <artifactId>s3-wagon-private</artifactId>
-      <version>1.3.2</version>
+      <groupId>medley</groupId>
+      <artifactId>medley</artifactId>
+      <version>1.3.0</version>
     </dependency>
     <dependency>
-      <groupId>com.cemerick</groupId>
-      <artifactId>pomegranate</artifactId>
-      <version>1.1.0</version>
+      <groupId>org.clojure</groupId>
+      <artifactId>tools.deps.alpha</artifactId>
+      <version>0.9.863</version>
     </dependency>
   </dependencies>
   <build>

--- a/src/deps_deploy/deps_deploy.clj
+++ b/src/deps_deploy/deps_deploy.clj
@@ -5,8 +5,7 @@
             [clojure.pprint :as pp]
             [clojure.java.io :as io]
             [clojure.data.xml :as xml]
-            [clojure.tools.deps.alpha :as t]
-            [medley.core :refer [assoc-some]])
+            [clojure.tools.deps.alpha :as t])
   (:import [org.springframework.build.aws.maven
             PrivateS3Wagon SimpleStorageServiceWagon]
             ;; maven-core
@@ -87,6 +86,16 @@
 
 (defn- artifact [{:keys [group-id artifact-id version]}]
   (str group-id "/" artifact-id "-" version))
+
+(defn- assoc-some
+  "Associates a key k, with a value v in a map m, if and only if v is not nil.
+   Copied from https://github.com/weavejester/medley"
+  ([m k v]
+   (if (nil? v) m (assoc m k v)))
+  ([m k v & kvs]
+   (reduce (fn [m [k v]] (assoc-some m k v))
+           (assoc-some m k v)
+           (partition 2 kvs))))
 
 (defn- read-edn-files
   "Given as options map, use tools.deps.alpha to read and merge the

--- a/src/deps_deploy/deps_deploy.clj
+++ b/src/deps_deploy/deps_deploy.clj
@@ -151,7 +151,7 @@
                            opts))
                      :else opts))
                options
-               options))))
+               options)))
 
 (defmulti deploy* :installer)
 


### PR DESCRIPTION
Here is a first draft implementation of this feature: 
- exec-args values that are keywords are resolved/replaced with matching `:aliases` keys (except for the values of `:installer`, which ARE keywords)
- The value of the key `:repository` is a string, it is resolved/replaced with matching keys from the `:mvn/repos` map
- Authentication credentials are obtained from ~/.m2/settings.xml
