### PR TITLE
ensure pom file path respects t.deps dir path resolution

### DIFF
--- a/src/deps_deploy/deps_deploy.clj
+++ b/src/deps_deploy/deps_deploy.clj
@@ -1,22 +1,19 @@
 (ns deps-deploy.deps-deploy
   (:require [cemerick.pomegranate.aether :as aether]
             [deps-deploy.gpg :as gpg]
-            [clojure.edn :as edn]
-            [clojure.pprint :as pp]
             [clojure.java.io :as io]
             [clojure.data.xml :as xml]
-            [clojure.tools.deps.alpha :as t])
+            [clojure.tools.deps.alpha :as t]
+            [clojure.tools.deps.alpha.util.dir :as dir])
   (:import [org.springframework.build.aws.maven
             PrivateS3Wagon SimpleStorageServiceWagon]
             ;; maven-core
-            [org.apache.maven.settings DefaultMavenSettingsBuilder Settings Server Mirror]
+           [org.apache.maven.settings DefaultMavenSettingsBuilder Settings Server]
             ;; maven-settings-builder
-            [org.apache.maven.settings.building DefaultSettingsBuilderFactory]))
-
+           [org.apache.maven.settings.building DefaultSettingsBuilderFactory]))
 
 (aether/register-wagon-factory! "s3p" #(PrivateS3Wagon.))
 (aether/register-wagon-factory! "s3" #(SimpleStorageServiceWagon.))
-
 
 (def default-repo-settings {"clojars" {:url (or (System/getenv "CLOJARS_URL") "https://clojars.org/repo")
                                        :username (System/getenv "CLOJARS_USERNAME")
@@ -70,7 +67,7 @@
 
 (defn sign! [pom jar-file sign-key-id]
   (let [passphrase (gpg/read-passphrase)
-        sign-op! (if sign-key-id 
+        sign-op! (if sign-key-id
                    (partial gpg/sign-with-key! sign-key-id)
                    (partial gpg/sign! passphrase))]
     [(sign-op! pom) (sign-op! jar-file)]))
@@ -120,8 +117,8 @@
   "Copied from clojure.tools.deps.alpha"
   ^Settings []
   (.buildSettings
-    (doto (DefaultMavenSettingsBuilder.)
-      (set-settings-builder (.newInstance (DefaultSettingsBuilderFactory.))))))
+   (doto (DefaultMavenSettingsBuilder.)
+     (set-settings-builder (.newInstance (DefaultSettingsBuilderFactory.))))))
 
 (defn- get-repo-settings
   [repo mvn-repos]
@@ -150,18 +147,18 @@
     (reduce-kv (fn [opts k v]
                  (cond
                    (and (not= :installer k) (keyword? v))
-                     (if (contains? aliases v)
-                       (assoc opts k (get aliases v))
-                       (do
-                         (println k "has value" v "which is an unknown alias")
-                         opts))
-                     (and (= :repository k) (string? v))
-                       (if-let [repo-map (get-repo-settings v mvn-repos)]
-                         (assoc opts k {v repo-map})
-                         (do
-                           (println k "has value" v "which is an unknown :mvn/repos")
-                           opts))
-                     :else opts))
+                   (if (contains? aliases v)
+                     (assoc opts k (get aliases v))
+                     (do
+                       (println k "has value" v "which is an unknown alias")
+                       opts))
+                   (and (= :repository k) (string? v))
+                   (if-let [repo-map (get-repo-settings v mvn-repos)]
+                     (assoc opts k {v repo-map})
+                     (do
+                       (println k "has value" v "which is an unknown :mvn/repos")
+                       opts))
+                   :else opts))
                options
                options)))
 
@@ -217,8 +214,8 @@
   "
   [options]
   (let [{:keys [pom-file sign-releases? sign-key-id artifact] :as opts} (preprocess-options options)
-         pom (slurp (or pom-file "pom.xml"))
-         coordinates (coordinates-from-pom pom)
+        pom (slurp (dir/canonicalize (io/file (or pom-file "pom.xml"))))
+        coordinates (coordinates-from-pom pom)
         artifact (str artifact)]
     (spit (versioned-pom-filename coordinates) pom)
 
@@ -229,7 +226,6 @@
               :coordinates coordinates))
       (finally
         (.delete (java.io.File. (versioned-pom-filename coordinates)))))))
-
 
 ;; command line mode
 (defn -main [deploy-or-install artifact & [sign-releases sign-key-id]]


### PR DESCRIPTION
This makes it so that pom file path resolutions abides by tools.deps notion of relative path at runtime. If the path specified is absolute nothing changes, if it's relative it will be to the https://github.com/clojure/tools.deps.alpha/blob/master/src/main/clojure/clojure/tools/deps/alpha/util/dir.clj#L19 value. 

That makes it possible to use deps-deploy with tasks that will alter that value at runtime (like say in a "multimodule" tool).

... + some linting (removing dead imports, whitespace, etc)