### PR TITLE
Fix aether property to write checksums for new maven versions

### DIFF
--- a/src/deps_deploy/deps_deploy.clj
+++ b/src/deps_deploy/deps_deploy.clj
@@ -179,6 +179,7 @@
         opts (assoc opts :repository repository)]
     (print-deploy-message opts)
     (java.lang.System/setProperty "aether.checksums.forSignature" "true")
+    (java.lang.System/setProperty "aether.checksums.omitChecksumsForExtensions" "")
     (aether/deploy :artifact-map artifact-map
                    :repository repository
                    :transfer-listener :stdout


### PR DESCRIPTION
I've been attempting to publish a new version of one of my projects with `deps-deploy` for a bit and banging my head into a wall, because I kept getting a 403 error due to missing checksums:

```
Deploying com.amperity/dialog-1.1.101 to repository clojars as greglook
Sending com/amperity/dialog/1.1.101/dialog-1.1.101.pom (2k)
    to https://clojars.org/repo/
Sending com/amperity/dialog/1.1.101/dialog-1.1.101.jar (24k)
    to https://clojars.org/repo/
Sending com/amperity/dialog/1.1.101/dialog-1.1.101.pom.asc (1k)
    to https://clojars.org/repo/
Sending com/amperity/dialog/1.1.101/dialog-1.1.101.jar.asc (1k)
    to https://clojars.org/repo/
Retrieving com/amperity/dialog/maven-metadata.xml (1k)
    from https://clojars.org/repo/
Sending com/amperity/dialog/maven-metadata.xml (1k)
    to https://clojars.org/repo/
Could not transfer metadata com.amperity:dialog/maven-metadata.xml from/to clojars (https://clojars.org/repo): Authorization failed for https://clojars.org/repo/com/amperity/dialog/maven-metadata.xml 403 Forbidden - no checksums provided for dialog-1.1.101.pom.asc
Execution error (AuthorizationException) at org.apache.maven.wagon.shared.http.AbstractHttpClientWagon/put (AbstractHttpClientWagon.java:806).
Authorization failed for https://clojars.org/repo/com/amperity/dialog/maven-metadata.xml 403 Forbidden - no checksums provided for dialog-1.1.101.pom.asc
```

I found a couple of previous issues related to this, including https://github.com/slipset/deps-deploy/issues/11, but the fix supplied there was definitely in the version I was using and yet I still couldn't published signed artifacts. This prior change sets the `aether.checksums.forSignature` property to true, which presumably gets the maven library to compute these signatures on the fly.

My investigation eventually led me to this page on [Maven Artifact Resolver configuration options](https://maven.apache.org/components/resolver/configuration.html), and I noticed that in the newer versions the option has changed to `aether.checksums.omitChecksumsForExtensions`. The description for that says:
> Note: to achieve 1.7.x aether.checksums.forSignature=true behaviour, pass empty string as value for this property.

I added that setting alongside the older one to maintain backwards compatibility, and the deploy worked after that.
