### PR TITLE
Adds antq and upgrades dependencies [#56]

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,16 +1,16 @@
 {:paths ["src"]
- :deps {org.clojure/clojure {:mvn/version "1.10.3"}
-        clj-commons/pomegranate {:mvn/version "1.2.1"}
+ :deps {org.clojure/clojure {:mvn/version "1.11.1"}
+        clj-commons/pomegranate {:mvn/version "1.2.23"}
         s3-wagon-private/s3-wagon-private {:mvn/version "1.3.5"}
-        org.clojure/data.xml {:mvn/version "0.2.0-alpha6"}
-        org.clojure/tools.deps.alpha {:mvn/version "0.12.1109"}
-        org.apache.maven/maven-settings {:mvn/version "3.8.4"}
-        org.apache.maven/maven-settings-builder {:mvn/version "3.8.4"}
+        org.clojure/data.xml {:mvn/version "0.2.0-alpha8"}
+        org.clojure/tools.deps.alpha {:mvn/version "0.15.1254"}
+        org.apache.maven/maven-settings {:mvn/version "3.9.4"}
+        org.apache.maven/maven-settings-builder {:mvn/version "3.9.4"}
         org.slf4j/slf4j-nop {:mvn/version "RELEASE"}
         org.sonatype.plexus/plexus-sec-dispatcher {:mvn/version "1.4"}}
 
  :aliases {:test {:extra-deps {io.github.cognitect-labs/test-runner
-                              {:git/tag "v0.5.0" :git/sha "b3fd0d2"}}
+                              {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
                   :extra-paths ["test"]
                   :exec-fn cognitect.test-runner.api/test}
 
@@ -28,13 +28,13 @@
                                  :version     :mvn/version
                                  :sync-pom true}}
 
-           :deploy {:extra-deps {slipset/deps-deploy {:mvn/version "0.2.0"}}
+           :deploy {:extra-deps {slipset/deps-deploy {:mvn/version "0.2.1"}}
                     :exec-fn deps-deploy.deps-deploy/deploy
                     :exec-args {:installer :remote
                                 :sign-releases? true
                                 :artifact :jar/file-name}}
 
-           :install {:extra-deps {slipset/deps-deploy {:mvn/version "0.2.0"}}
+           :install {:extra-deps {slipset/deps-deploy {:mvn/version "0.2.1"}}
                      :exec-fn deps-deploy.deps-deploy/deploy
                      :exec-args {:installer :local
                                  :artifact :jar/file-name}}

--- a/deps.edn
+++ b/deps.edn
@@ -3,7 +3,7 @@
         clj-commons/pomegranate {:mvn/version "1.2.23"}
         s3-wagon-private/s3-wagon-private {:mvn/version "1.3.5"}
         org.clojure/data.xml {:mvn/version "0.2.0-alpha8"}
-        org.clojure/tools.deps.alpha {:mvn/version "0.15.1254"}
+        org.clojure/tools.deps {:mvn/version "0.18.1354"}
         org.apache.maven/maven-settings {:mvn/version "3.9.4"}
         org.apache.maven/maven-settings-builder {:mvn/version "3.9.4"}
         org.slf4j/slf4j-nop {:mvn/version "RELEASE"}

--- a/deps.edn
+++ b/deps.edn
@@ -37,4 +37,7 @@
            :install {:extra-deps {slipset/deps-deploy {:mvn/version "0.2.0"}}
                      :exec-fn deps-deploy.deps-deploy/deploy
                      :exec-args {:installer :local
-                                 :artifact :jar/file-name}}}}
+                                 :artifact :jar/file-name}}
+           :outdated {;; Note that it is `:deps`, not `:extra-deps`
+                      :deps {com.github.liquidz/antq {:mvn/version "RELEASE"}}
+                      :main-opts ["-m" "antq.core"]}}}

--- a/pom.xml
+++ b/pom.xml
@@ -10,27 +10,27 @@
     <dependency>
       <groupId>org.clojure</groupId>
       <artifactId>clojure</artifactId>
-      <version>1.10.3</version>
+      <version>1.11.1</version>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-settings-builder</artifactId>
-      <version>3.8.4</version>
+      <version>3.9.4</version>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-settings</artifactId>
-      <version>3.8.4</version>
+      <version>3.9.4</version>
     </dependency>
     <dependency>
       <groupId>org.clojure</groupId>
       <artifactId>tools.deps.alpha</artifactId>
-      <version>0.12.1109</version>
+      <version>0.15.1254</version>
     </dependency>
     <dependency>
       <groupId>org.clojure</groupId>
       <artifactId>data.xml</artifactId>
-      <version>0.2.0-alpha6</version>
+      <version>0.2.0-alpha8</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
@@ -50,7 +50,7 @@
     <dependency>
       <groupId>clj-commons</groupId>
       <artifactId>pomegranate</artifactId>
-      <version>1.2.1</version>
+      <version>1.2.23</version>
     </dependency>
   </dependencies>
   <build>


### PR DESCRIPTION
This PR:
1. adds [`antq`](https://github.com/liquidz/antq) (a handy "outdated dependencies" checker) to the set of build aliases
2. upgrades all outdated dependencies (which, as a side effect, fixes issue #56)
3. migrates from `tools.deps.alpha` to `tools.deps` GA