### PR TITLE
Read username/password from env even when not using clojars

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,18 +24,13 @@
     </dependency>
     <dependency>
       <groupId>org.clojure</groupId>
-      <artifactId>tools.deps.alpha</artifactId>
-      <version>0.15.1254</version>
-    </dependency>
-    <dependency>
-      <groupId>org.clojure</groupId>
       <artifactId>data.xml</artifactId>
       <version>0.2.0-alpha8</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-nop</artifactId>
-      <version>2.0.7</version>
+      <version>2.0.9</version>
     </dependency>
     <dependency>
       <groupId>s3-wagon-private</groupId>
@@ -46,6 +41,11 @@
       <groupId>org.sonatype.plexus</groupId>
       <artifactId>plexus-sec-dispatcher</artifactId>
       <version>1.4</version>
+    </dependency>
+    <dependency>
+      <groupId>org.clojure</groupId>
+      <artifactId>tools.deps</artifactId>
+      <version>0.18.1354</version>
     </dependency>
     <dependency>
       <groupId>clj-commons</groupId>

--- a/src/deps_deploy/deps_deploy.clj
+++ b/src/deps_deploy/deps_deploy.clj
@@ -3,8 +3,8 @@
             [deps-deploy.gpg :as gpg]
             [clojure.java.io :as io]
             [clojure.data.xml :as xml]
-            [clojure.tools.deps.alpha :as t]
-            [clojure.tools.deps.alpha.util.dir :as dir])
+            [clojure.tools.deps :as t]
+            [clojure.tools.deps.util.dir :as dir])
   (:import [org.springframework.build.aws.maven
             PrivateS3Wagon SimpleStorageServiceWagon]
             ;; maven-core

--- a/src/deps_deploy/deps_deploy.clj
+++ b/src/deps_deploy/deps_deploy.clj
@@ -15,9 +15,10 @@
 (aether/register-wagon-factory! "s3p" #(PrivateS3Wagon.))
 (aether/register-wagon-factory! "s3" #(SimpleStorageServiceWagon.))
 
-(def default-repo-settings {"clojars" {:url (or (System/getenv "CLOJARS_URL") "https://clojars.org/repo")
-                                       :username (System/getenv "CLOJARS_USERNAME")
-                                       :password (System/getenv "CLOJARS_PASSWORD")}})
+(def default-repo-settings {:id "clojars"
+                            :url (or (System/getenv "CLOJARS_URL") "https://clojars.org/repo")
+                            :username (System/getenv "CLOJARS_USERNAME")
+                            :password (System/getenv "CLOJARS_PASSWORD")})
 
 (def artifact-id-tag :xmlns.http%3A%2F%2Fmaven.apache.org%2FPOM%2F4.0.0/artifactId)
 (def group-id-tag :xmlns.http%3A%2F%2Fmaven.apache.org%2FPOM%2F4.0.0/groupId)
@@ -175,8 +176,8 @@
       (println "Deploying" (artifact coordinates) "to repository" id "."))))
 
 (defmethod deploy* :remote [{:keys [artifact-map coordinates repository] :as opts}]
-  (let [repository (or repository default-repo-settings)
-        opts (assoc opts :repository repository)]
+
+  (let [opts (assoc opts :repository repository)]
     (print-deploy-message opts)
     (java.lang.System/setProperty "aether.checksums.forSignature" "true")
     (java.lang.System/setProperty "aether.checksums.omitChecksumsForExtensions" "")
@@ -217,14 +218,24 @@
   (let [{:keys [pom-file sign-releases? sign-key-id artifact] :as opts} (preprocess-options options)
         pom (slurp (dir/canonicalize (io/file (or pom-file "pom.xml"))))
         coordinates (coordinates-from-pom pom)
-        artifact (str artifact)]
+        artifact (str artifact)
+        [exec-args-repo-id exec-args-repo-settings] (->> options :repository (into []) first)
+        repository {(or exec-args-repo-id
+                        (:id default-repo-settings))
+                    {:url (or (:url exec-args-repo-settings)
+                              (:url default-repo-settings))
+                     :username (or (:username exec-args-repo-settings)
+                                   (:username default-repo-settings))
+                     :password (or (:password exec-args-repo-settings)
+                                   (:password default-repo-settings))}}]
     (spit (versioned-pom-filename coordinates) pom)
 
     (try
       (deploy*
        (assoc opts
               :artifact-map (all-artifacts sign-releases? coordinates artifact sign-key-id)
-              :coordinates coordinates))
+              :coordinates  coordinates
+              :repository   repository))
       (finally
         (.delete (java.io.File. (versioned-pom-filename coordinates)))))))
 


### PR DESCRIPTION
Allows reading username and password from `$CLOJARS_USERNAME` and `$CLOJARS_PASSWORD` even when `[:exec-args :repository]` is set in the deps.edn alias.

If the user has defined several repositories for some reason, behaviour is somewhat unspecified; the first one returned by `keys` will be used (this mirrors the existing behaviour).

Fixes #59