### PR TITLE
fix: correct handling of repository string

### DIFF
--- a/src/deps_deploy/deps_deploy.clj
+++ b/src/deps_deploy/deps_deploy.clj
@@ -219,7 +219,7 @@
         pom (slurp (dir/canonicalize (io/file (or pom-file "pom.xml"))))
         coordinates (coordinates-from-pom pom)
         artifact (str artifact)
-        [exec-args-repo-id exec-args-repo-settings] (->> options :repository (into []) first)
+        [exec-args-repo-id exec-args-repo-settings] (->> opts :repository (into []) first)
         repository {(or exec-args-repo-id
                         (:id default-repo-settings))
                     {:url (or (:url exec-args-repo-settings)


### PR DESCRIPTION
Hit the following error when trying to use `0.2.2` in CI
```
nth not supported on this type: Character
```

I reproduced it locally and the reason is that line `222` uses `options` instead of the `opts` that have already been processed.

This means that when `:repository` is a string such as `"repo"` we end up with
```clojure
(->> options
     :repository ;; => "repo"
     (into []) ;; => [\r \e \p \o]
      first) ;; => \r
```
which it then tries to destructure with `[exec-args-repo-id exec-args-repo-settings]`.