### PR TITLE
Support plain password of Maven settings.xml for tools.deps compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Clojars Project](https://img.shields.io/clojars/v/slipset/deps-deploy.svg)](https://clojars.org/slipset/deps-deploy)
+[![Clojars Project](https://img.shields.io/clojars/v/xcoo/deps-deploy.svg)](https://clojars.org/xcoo/deps-deploy)
 # deps-deploy
 
 A Clojure library to deploy your stuff to clojars with `clj` or `clojure`. It's a very thin wrapper around
@@ -11,7 +11,7 @@ It will read your Clojars username/token from the environment variables `CLOJARS
 To deploy to Clojars, simply merge
 
 ```clojure
-{:deploy {:extra-deps {slipset/deps-deploy {:mvn/version "RELEASE"}}
+{:deploy {:extra-deps {xcoo/deps-deploy {:mvn/version "RELEASE"}}
           :exec-fn deps-deploy.deps-deploy/deploy
           :exec-args {:installer :remote
                        :sign-releases? true
@@ -36,7 +36,7 @@ to hold private JARs etc...
 If you want to sign using another key than the default key, you can specify the signing key id:
 
 ```clojure
-{:deploy {:extra-deps {slipset/deps-deploy {:mvn/version "RELEASE"}}
+{:deploy {:extra-deps {xcoo/deps-deploy {:mvn/version "RELEASE"}}
           :exec-fn deps-deploy.deps-deploy/deploy
           :exec-args {:installer :remote
                        :sign-releases? true
@@ -80,7 +80,7 @@ Long story short, just go find yourself a token and use it in lieu of your passw
 
 `deps-deploy` also supports installing to your local `.m2` repo, by invoking `install` instead of `deploy`:
 ```clojure
-{:install {:extra-deps {slipset/deps-deploy {:mvn/version "RELEASE"}}
+{:install {:extra-deps {xcoo/deps-deploy {:mvn/version "RELEASE"}}
            :exec-fn deps-deploy.deps-deploy/deploy
            :exec-args {:installer :local
                        :artifact "deps-deploy.jar"}}

--- a/deps.edn
+++ b/deps.edn
@@ -1,11 +1,11 @@
 {:paths ["src"]
- :deps {org.clojure/clojure {:mvn/version "1.11.1"}
-        clj-commons/pomegranate {:mvn/version "1.2.23"}
+ :deps {org.clojure/clojure {:mvn/version "1.12.0"}
+        clj-commons/pomegranate {:mvn/version "1.2.24"}
         s3-wagon-private/s3-wagon-private {:mvn/version "1.3.5"}
-        org.clojure/data.xml {:mvn/version "0.2.0-alpha8"}
-        org.clojure/tools.deps {:mvn/version "0.18.1354"}
-        org.apache.maven/maven-settings {:mvn/version "3.9.4"}
-        org.apache.maven/maven-settings-builder {:mvn/version "3.9.4"}
+        org.clojure/data.xml {:mvn/version "0.2.0-alpha9"}
+        org.clojure/tools.deps {:mvn/version "0.21.1467"}
+        org.apache.maven/maven-settings {:mvn/version "3.9.9"}
+        org.apache.maven/maven-settings-builder {:mvn/version "3.9.9"}
         org.slf4j/slf4j-nop {:mvn/version "RELEASE"}
         org.sonatype.plexus/plexus-sec-dispatcher {:mvn/version "1.4"}}
 
@@ -15,8 +15,8 @@
                   :exec-fn cognitect.test-runner.api/test}
 
            :mvn/artifact-id deps-deploy
-           :mvn/group-id    slipset
-           :mvn/version     "0.2.1"
+           :mvn/group-id    xcoo
+           :mvn/version     "0.3.0-SNAPSHOT"
            :jar/file-name   "deps-deploy.jar"
 
            :depstar {:replace-deps
@@ -28,13 +28,13 @@
                                  :version     :mvn/version
                                  :sync-pom true}}
 
-           :deploy {:extra-deps {slipset/deps-deploy {:mvn/version "0.2.1"}}
+           :deploy {:extra-deps {xcoo/deps-deploy {:mvn/version "0.3.0"}}
                     :exec-fn deps-deploy.deps-deploy/deploy
                     :exec-args {:installer :remote
                                 :sign-releases? true
                                 :artifact :jar/file-name}}
 
-           :install {:extra-deps {slipset/deps-deploy {:mvn/version "0.2.1"}}
+           :install {:extra-deps {xcoo/deps-deploy {:mvn/version "0.3.0"}}
                      :exec-fn deps-deploy.deps-deploy/deploy
                      :exec-args {:installer :local
                                  :artifact :jar/file-name}}

--- a/pom.xml
+++ b/pom.xml
@@ -2,35 +2,35 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <packaging>jar</packaging>
-  <groupId>slipset</groupId>
+  <groupId>xcoo</groupId>
   <artifactId>deps-deploy</artifactId>
-  <version>0.2.1</version>
+  <version>0.3.0</version>
   <name>deps-deploy</name>
   <dependencies>
     <dependency>
       <groupId>org.clojure</groupId>
       <artifactId>clojure</artifactId>
-      <version>1.11.1</version>
+      <version>1.12.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-settings-builder</artifactId>
-      <version>3.9.4</version>
+      <version>3.9.9</version>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-settings</artifactId>
-      <version>3.9.4</version>
+      <version>3.9.9</version>
     </dependency>
     <dependency>
       <groupId>org.clojure</groupId>
       <artifactId>data.xml</artifactId>
-      <version>0.2.0-alpha8</version>
+      <version>0.2.0-alpha9</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-nop</artifactId>
-      <version>2.0.9</version>
+      <version>2.0.16</version>
     </dependency>
     <dependency>
       <groupId>s3-wagon-private</groupId>
@@ -45,12 +45,12 @@
     <dependency>
       <groupId>org.clojure</groupId>
       <artifactId>tools.deps</artifactId>
-      <version>0.18.1354</version>
+      <version>0.21.1467</version>
     </dependency>
     <dependency>
       <groupId>clj-commons</groupId>
       <artifactId>pomegranate</artifactId>
-      <version>1.2.23</version>
+      <version>1.2.24</version>
     </dependency>
   </dependencies>
   <build>

--- a/test/deps_deploy/deps_deploy_test.clj
+++ b/test/deps_deploy/deps_deploy_test.clj
@@ -1,7 +1,0 @@
-(ns deps-deploy.deps-deploy-test
-  (:require [clojure.test :refer :all]
-            [deps-deploy.deps-deploy :refer :all]))
-
-(deftest a-test
-  (testing "FIXME, I fail."
-    (is (= 0 1))))


### PR DESCRIPTION
I added support for a plain password in the Maven settings.xml to ensure compatibility with `tools.deps`. 

As you may know, `tools.deps` currently does not support encrypted passwords in the Maven settings.xml. For more details, please refer to https://clojure.atlassian.net/browse/TDEPS-255.