### PR TITLE
Update to pomegranate 1.3.27

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,6 +1,6 @@
 {:paths ["src"]
  :deps {org.clojure/clojure {:mvn/version "1.12.4"}
-        clj-commons/pomegranate {:mvn/version "1.3.26"}
+        clj-commons/pomegranate {:mvn/version "1.3.27"}
         s3-wagon-private/s3-wagon-private {:mvn/version "1.3.5"}
         org.clojure/tools.deps {:mvn/version "0.18.1354"}
         org.apache.maven/maven-settings {:mvn/version "3.9.4"}


### PR DESCRIPTION
The only fix in this version is locking around deploy status output, as uploads are now parallel, resulting in interleaved output.

See https://github.com/clj-commons/pomegranate/pull/243