### PR TITLE
tools.deps/maven updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,3 +84,5 @@ pom.xml.asc
 # Calva and clojure-lsp
 .calva
 .lsp
+.clj-kondo/.cache
+.portal

--- a/deps.edn
+++ b/deps.edn
@@ -2,9 +2,9 @@
  :deps {org.clojure/clojure {:mvn/version "1.12.4"}
         clj-commons/pomegranate {:mvn/version "1.3.27"}
         s3-wagon-private/s3-wagon-private {:mvn/version "1.3.5"}
-        org.clojure/tools.deps {:mvn/version "0.18.1354"}
-        org.apache.maven/maven-settings {:mvn/version "3.9.4"}
-        org.apache.maven/maven-settings-builder {:mvn/version "3.9.4"}
+        org.clojure/tools.deps.edn {:mvn/version "0.9.27"}
+        org.apache.maven/maven-settings {:mvn/version "3.9.16"}
+        org.apache.maven/maven-settings-builder {:mvn/version "3.9.16"}
         org.slf4j/slf4j-nop {:mvn/version "RELEASE"}
         org.sonatype.plexus/plexus-sec-dispatcher {:mvn/version "1.4"}}
 

--- a/deps.edn
+++ b/deps.edn
@@ -5,8 +5,7 @@
         org.clojure/tools.deps.edn {:mvn/version "0.9.27"}
         org.apache.maven/maven-settings {:mvn/version "3.9.16"}
         org.apache.maven/maven-settings-builder {:mvn/version "3.9.16"}
-        org.slf4j/slf4j-nop {:mvn/version "RELEASE"}
-        org.sonatype.plexus/plexus-sec-dispatcher {:mvn/version "1.4"}}
+        org.slf4j/slf4j-nop {:mvn/version "RELEASE"}}
 
  :aliases {:test {:extra-deps {io.github.cognitect-labs/test-runner
                               {:git/tag "v0.5.1" :git/sha "dfb30dd"}}

--- a/pom.xml
+++ b/pom.xml
@@ -20,14 +20,19 @@
       <version>1.12.4</version>
     </dependency>
     <dependency>
+      <groupId>org.clojure</groupId>
+      <artifactId>tools.deps.edn</artifactId>
+      <version>0.9.27</version>
+    </dependency>
+    <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-settings-builder</artifactId>
-      <version>3.9.4</version>
+      <version>3.9.16</version>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-settings</artifactId>
-      <version>3.9.4</version>
+      <version>3.9.16</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
@@ -40,19 +45,9 @@
       <version>1.3.5</version>
     </dependency>
     <dependency>
-      <groupId>org.sonatype.plexus</groupId>
-      <artifactId>plexus-sec-dispatcher</artifactId>
-      <version>1.4</version>
-    </dependency>
-    <dependency>
-      <groupId>org.clojure</groupId>
-      <artifactId>tools.deps</artifactId>
-      <version>0.18.1354</version>
-    </dependency>
-    <dependency>
       <groupId>clj-commons</groupId>
       <artifactId>pomegranate</artifactId>
-      <version>1.3.26</version>
+      <version>1.3.27</version>
     </dependency>
   </dependencies>
   <build>

--- a/src/deps_deploy/deps_deploy.clj
+++ b/src/deps_deploy/deps_deploy.clj
@@ -2,7 +2,7 @@
   (:require [cemerick.pomegranate.aether :as aether]
             [deps-deploy.gpg :as gpg]
             [clojure.java.io :as io]
-            [clojure.tools.deps :as t]
+            [clojure.tools.deps.edn :as t]
             [clojure.tools.deps.util.dir :as dir])
   (:import [java.util Properties]
            [org.springframework.build.aws.maven
@@ -10,10 +10,10 @@
            ;; maven-model
            [org.apache.maven.model Model]
            [org.apache.maven.model.io.xpp3 MavenXpp3Reader]
-           ;; maven-core
-           [org.apache.maven.settings DefaultMavenSettingsBuilder Settings Server]
-            ;; maven-settings-builder
-           [org.apache.maven.settings.building DefaultSettingsBuilderFactory]))
+           ;; maven-settings
+           [org.apache.maven.settings Settings Server]
+           ;; maven-settings-builder
+           [org.apache.maven.settings.building SettingsBuilder DefaultSettingsBuilderFactory DefaultSettingsBuildingRequest]))
 
 (aether/register-wagon-factory! "s3p" #(PrivateS3Wagon.))
 (aether/register-wagon-factory! "s3" #(SimpleStorageServiceWagon.))
@@ -94,24 +94,20 @@
   "Given as options map, use tools.deps.alpha to read and merge the
   applicable `deps.edn` files, from depstar"
   [{:keys [repro] :or {repro true}}]
-  (let [{:keys [root-edn user-edn project-edn]} (t/find-edn-maps)]
+  (let [{:keys [root user project]} (t/create-edn-maps)]
     (t/merge-edns (if repro
-                    [root-edn project-edn]
-                    [root-edn user-edn project-edn]))))
-
-(defn- set-settings-builder
-  "Copied from clojure.tools.deps.alpha"
-  [^DefaultMavenSettingsBuilder default-builder settings-builder]
-  (doto (.. default-builder getClass (getDeclaredField "settingsBuilder"))
-    (.setAccessible true)
-    (.set default-builder settings-builder)))
+                    [root project]
+                    [root user project]))))
 
 (defn- get-settings
-  "Copied from clojure.tools.deps.alpha"
+  "Copied from clojure.tools.deps.util.maven"
   ^Settings []
-  (.buildSettings
-   (doto (DefaultMavenSettingsBuilder.)
-     (set-settings-builder (.newInstance (DefaultSettingsBuilderFactory.))))))
+  (let [^SettingsBuilder builder (.newInstance (DefaultSettingsBuilderFactory.))
+        request (DefaultSettingsBuildingRequest.)
+        user-settings (io/file (System/getProperty "user.home") ".m2" "settings.xml")]
+    (when (.exists user-settings)
+      (.setUserSettingsFile request user-settings))
+    (.getEffectiveSettings (.build builder request))))
 
 (defn- get-repo-settings
   [repo mvn-repos]


### PR DESCRIPTION
Switches from tools.deps(.alpha) to tools.deps.edn for code that reads deps.edn files.

Updates get-settings code to match latest tools.deps.util.maven for latest Maven versions.

Removes org.sonatype.plexus/plexus-sec-dispatcher dependency, which causes client projects to fail (when requiring deps-deploy).