### PR TITLE
Don't ask for passphrase when using sign-key-id

### DIFF
--- a/src/deps_deploy/deps_deploy.clj
+++ b/src/deps_deploy/deps_deploy.clj
@@ -59,10 +59,9 @@
   [(symbol (str group-id "/" artifact-id)) version])
 
 (defn sign! [pom jar-file sign-key-id]
-  (let [passphrase (gpg/read-passphrase)
-        sign-op! (if sign-key-id
+  (let [sign-op! (if sign-key-id
                    (partial gpg/sign-with-key! sign-key-id)
-                   (partial gpg/sign! passphrase))]
+                   (partial gpg/sign! (gpg/read-passphrase)))]
     [(sign-op! pom) (sign-op! jar-file)]))
 
 (defn artifacts [version files]


### PR DESCRIPTION
I ran into this while publishing multiple libraries in quick succession; even when setting `sign-key-id` I would still get asked for a passphrase once per library.